### PR TITLE
Remove border on right of pinned tabs

### DIFF
--- a/css/userChrome-theme.css
+++ b/css/userChrome-theme.css
@@ -1547,4 +1547,8 @@ spacer[part=overflow-end-indicator] {
   #identity-box {
     margin-inline-end: 0 !important;
   }
+
+  #tabbrowser-tabs[haspinnedtabs]:not([positionpinnedtabs]) > #tabbrowser-arrowscrollbox > .tabbrowser-tab[first-visible-unpinned-tab] {
+    margin-inline-start: 0 !important;
+  }
 }

--- a/css/userChrome-vibrancy.css
+++ b/css/userChrome-vibrancy.css
@@ -1553,4 +1553,8 @@ spacer[part=overflow-end-indicator] {
   #identity-box {
     margin-inline-end: 0 !important;
   }
+
+  #tabbrowser-tabs[haspinnedtabs]:not([positionpinnedtabs]) > #tabbrowser-arrowscrollbox > .tabbrowser-tab[first-visible-unpinned-tab] {
+    margin-inline-start: 0 !important;
+  }
 }

--- a/css/userChrome.css
+++ b/css/userChrome.css
@@ -1527,4 +1527,8 @@ spacer[part=overflow-end-indicator] {
   #identity-box {
     margin-inline-end: 0 !important;
   }
+
+  #tabbrowser-tabs[haspinnedtabs]:not([positionpinnedtabs]) > #tabbrowser-arrowscrollbox > .tabbrowser-tab[first-visible-unpinned-tab] {
+    margin-inline-start: 0 !important;
+  }
 }

--- a/scss/userChrome.scss
+++ b/scss/userChrome.scss
@@ -1588,4 +1588,7 @@ $firefox-safari-style-vibrancy: false;
     #identity-box {
         margin-inline-end: 0 !important;
     }
+    #tabbrowser-tabs[haspinnedtabs]:not([positionpinnedtabs]) > #tabbrowser-arrowscrollbox > .tabbrowser-tab[first-visible-unpinned-tab] {
+        margin-inline-start: 0 !important;
+    }
 }


### PR DESCRIPTION
There is a space between the pinned tabs and the remaining tabs on Firefox Proton. This PR fixes that, although I find it odd that the original Firefox css has an `!important` flag.